### PR TITLE
refactor(handlers): implemented filehound

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cron": "^1.8.2",
     "discord.js": "^12.5.3",
     "express": "^4.17.1",
+    "filehound": "^1.17.4",
     "mongoose": "^5.11.14",
     "ms": "^2.1.3",
     "node-superfetch": "^0.1.10",

--- a/src/handlers/command.handler.js
+++ b/src/handlers/command.handler.js
@@ -1,19 +1,21 @@
-const { readdirSync } = require('fs');
+const filehound = require('filehound');
+const { parse, join } = require('path');
 
 module.exports = async client => {
-    let failed = [];
-    readdirSync('./src/commands/').forEach(dir => {
-        readdirSync(`./src/commands/${dir}/`)
-        .filter(f => f.endsWith('.js'))
-        .forEach(cmd => {
-            const command = require(`../commands/${dir}/${cmd}`);
-            if (command.name) {
-                client.commands.set(command.name, command);
-            } else {
-                failed.push(cmd);
-            }
-            if (command.aliases && Array.isArray(command.aliases)) command.aliases.forEach(a => client.aliases.set(a, command.name));
-        });
+    const failed = [];
+
+    filehound.create()
+    .path(join(process.cwd(),'src','commands'))
+    .ext('.js')
+    .findSync()
+    .forEach(cmd => {
+        const command = require(cmd);
+        if (command.name) {
+            client.commands.set(command.name, command);
+        } else {
+            failed.push(parse(cmd).base);
+        }
+        if (command.aliases && Array.isArray(command.aliases)) command.aliases.forEach(a => client.aliases.set(a, command.name));
     });
     client.stats._failed = failed;
 }

--- a/src/handlers/event.handler.js
+++ b/src/handlers/event.handler.js
@@ -1,13 +1,17 @@
-const { readdirSync } = require('fs');
+const filehound = require('filehound');
+const { parse, join } = require('path');
 
 module.exports = async client => {
     let loaded = 0;
-    readdirSync('./src/events/')
-    .filter(f => f.endsWith('.js'))
+
+    filehound.create()
+    .path(join(process.cwd(),'src','events'))
+    .ext('.js')
+    .findSync()
     .forEach(e => {
-        const event = require(`../events/${e}`);
+        const event = require(e);
         loaded++;
-        client.on(e.split('.').shift(), (...args) => {
+        client.on(parse(e).base.split('.')[0], (...args) => {
             client.stats.events++;
             event.run(client, ...args);
         });


### PR DESCRIPTION
## why?
yes

## why didn't you also push package-lock.json?
because I have `lockFileVersion: 1` and it fucks up everything

## is it better?
yes, it allows to load any js file inside of the folders recursively, so you don't have to explicitly keep a `folder/subfolder/file` structure. it also allows for finding other file extensions if you input an array (e.g. if you implemented TS or coffee in require)

## why did you add that ugly "process.cwd()"
because it's easier to work with it, since you have an absolute position with it, which is in most of the cases valuable.

## why did you replace `.shift()` with `[0]`?
do I really have to explain it?